### PR TITLE
List meson as build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,8 @@ Priority: optional
 Maintainer: Georges Basile Stavracas Neto <georges@endlessm.com>
 Uploaders: Georges Basile Stavracas Neto <georges@endlessm.com>
 Build-Depends:
- debhelper-compat (= 12)
+ debhelper-compat (= 12),
+ meson (>= 0.40.0)
 Standards-Version: 4.4.0
 Homepage: https://github.com/endlessm/eos-watermark-extension
 Vcs-Browser: https://github.com/endlessm/eos-watermark-extension


### PR DESCRIPTION
It is, in practice, the only dependency.

https://phabricator.endlessm.com/T28778